### PR TITLE
Stream Episode 16: TransportDataStore implementation

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -61,6 +61,8 @@ Since I'm always working on some side-projects, I decided to document the progre
 
 - Ep.15: https://github.com/JoaquimLey/transport-eta/pull/70
 
+- Ep.15: https://github.com/JoaquimLey/transport-eta/pull/74
+
 
 ## About the author
 Hi, my name is  **Joaquim Ley**, I'm a Software Engineer (Android).

--- a/transport-eta-android/data/src/main/java/com/joaquimley/data/source/FrameworkLocalStorage.kt
+++ b/transport-eta-android/data/src/main/java/com/joaquimley/data/source/FrameworkLocalStorage.kt
@@ -1,0 +1,18 @@
+package com.joaquimley.data.source
+
+import com.joaquimley.data.model.TransportEntity
+import io.reactivex.Completable
+import io.reactivex.Single
+
+interface FrameworkLocalStorage {
+
+    fun saveTransport(transportEntity: TransportEntity): Completable
+
+    fun deleteTransport(transportEntityId: String): Completable
+
+    fun getTransport(transportEntityId: String): Single<TransportEntity>
+
+    fun getAll(): Single<List<TransportEntity>>
+
+    fun clearAll(): Completable
+}

--- a/transport-eta-android/data/src/main/java/com/joaquimley/data/source/SharedPreferencesDataSource.kt
+++ b/transport-eta-android/data/src/main/java/com/joaquimley/data/source/SharedPreferencesDataSource.kt
@@ -1,3 +1,0 @@
-package com.joaquimley.data.source
-
-class SharedPreferencesDataSource

--- a/transport-eta-android/data/src/main/java/com/joaquimley/data/store/TransportDataStore.kt
+++ b/transport-eta-android/data/src/main/java/com/joaquimley/data/store/TransportDataStore.kt
@@ -7,19 +7,19 @@ import io.reactivex.Observable
 
 interface TransportDataStore {
 
-    fun markAsFavorite(transport: TransportEntity): Completable
+    fun markAsFavorite(transportEntity: TransportEntity): Completable
 
-    fun removeAsFavorite(transport: TransportEntity): Completable
+    fun removeAsFavorite(transportEntity: TransportEntity): Completable
 
     fun getAllFavorites(): Flowable<List<TransportEntity>>
 
     fun clearAllFavorites(): Completable
 
-    fun saveTransport(transport: TransportEntity): Completable
+    fun saveTransport(transportEntity: TransportEntity): Completable
 
-    fun deleteTransport(transport: String): Completable
+    fun deleteTransport(transportEntityId: String): Completable
 
-    fun getTransport(transportId: String): Observable<TransportEntity>
+    fun getTransport(transportEntityId: String): Observable<TransportEntity>
 
     fun getAll(): Flowable<List<TransportEntity>>
 

--- a/transport-eta-android/data/src/main/java/com/joaquimley/data/store/TransportDataStoreImpl.kt
+++ b/transport-eta-android/data/src/main/java/com/joaquimley/data/store/TransportDataStoreImpl.kt
@@ -1,7 +1,52 @@
 package com.joaquimley.data.store
 
-import com.joaquimley.data.source.SharedPreferencesDataSource
+import com.joaquimley.data.model.TransportEntity
+import com.joaquimley.data.source.FrameworkLocalStorage
+import io.reactivex.Completable
+import io.reactivex.Flowable
+import io.reactivex.Observable
 
-class TransportDataStoreImpl(val sharedPreferencesDataSource: SharedPreferencesDataSource) {
+class TransportDataStoreImpl(private val frameworkLocalStorage: FrameworkLocalStorage): TransportDataStore {
 
+    override fun markAsFavorite(transportEntity: TransportEntity): Completable {
+        return Completable.error(NotImplementedError("Won't be ready for v1.0"))
+    }
+
+    override fun removeAsFavorite(transportEntity: TransportEntity): Completable {
+        return Completable.error(NotImplementedError("Won't be ready for v1.0"))
+    }
+
+    override fun getAllFavorites(): Flowable<List<TransportEntity>> {
+        return Flowable.error(NotImplementedError("Won't be ready for v1.0"))
+    }
+
+    override fun clearAllFavorites(): Completable {
+        return Completable.error(NotImplementedError("Won't be ready for v1.0"))
+    }
+
+    override fun saveTransport(transportEntity: TransportEntity): Completable {
+        return frameworkLocalStorage.saveTransport(transportEntity)
+    }
+
+    override fun deleteTransport(transportEntityId: String): Completable {
+        return frameworkLocalStorage.deleteTransport(transportEntityId)
+    }
+
+    override fun getTransport(transportEntityId: String): Observable<TransportEntity> {
+        return  frameworkLocalStorage.getTransport(transportEntityId).toObservable()
+    }
+
+    override fun getAll(): Flowable<List<TransportEntity>> {
+        return frameworkLocalStorage.getAll().toFlowable()
+    }
+
+    // TODO Should these be in the [SmSController] instead?  [RequestEtaUseCase]
+    override fun requestTransportEta(transportCode: Int): Observable<TransportEntity> {
+        return Observable.error<TransportEntity>(NotImplementedError("Should these be in the [SmSController] instead?"))
+    }
+
+    // TODO Should these be in the [SmSController] instead?  [RequestEtaUseCase]
+    override fun cancelTransportEtaRequest(transportCode: Int?): Completable {
+        return Completable.error(NotImplementedError("Should these be in the [SmSController] instead?"))
+    }
 }

--- a/transport-eta-android/data/src/test/java/com/joaquimley/data/store/TransportDataStoreTest.kt
+++ b/transport-eta-android/data/src/test/java/com/joaquimley/data/store/TransportDataStoreTest.kt
@@ -1,0 +1,306 @@
+package com.joaquimley.data.store
+
+import com.joaquimley.data.factory.DataFactory
+import com.joaquimley.data.factory.TransportFactory
+import com.joaquimley.data.model.TransportEntity
+import com.joaquimley.data.source.FrameworkLocalStorage
+import com.nhaarman.mockitokotlin2.*
+import io.reactivex.Completable
+import io.reactivex.Flowable
+import io.reactivex.Single
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class TransportDataStoreTest {
+
+    private val robot = Robot()
+
+    private val mockFrameworkLocalStorage = mock<FrameworkLocalStorage>()
+
+    private lateinit var transportDataStore: TransportDataStore
+
+    @Before
+    fun setUp() {
+        transportDataStore = TransportDataStoreImpl(mockFrameworkLocalStorage)
+    }
+
+    @After
+    fun tearDown() {
+    }
+
+    @Test
+    fun markAsFavoriteThrowsNotYetImplemented() {
+        // Assemble
+
+        // Act
+        val result = transportDataStore.markAsFavorite(TransportFactory.makeTransportEntity()).test()
+        // Assert
+        result.assertError(NotImplementedError::class.java)
+    }
+
+    @Test
+    fun removeAsFavoriteThrowsNotYetImplemented() {
+        // Assemble
+
+        // Act
+        val result = transportDataStore.removeAsFavorite(TransportFactory.makeTransportEntity()).test()
+        // Assert
+        result.assertError(NotImplementedError::class.java)
+    }
+
+    @Test
+    fun getAllFavoritesThrowsNotYetImplemented() {
+        // Assemble
+
+        // Act
+        val result = transportDataStore.getAllFavorites().test()
+        // Assert
+        result.assertError(NotImplementedError::class.java)
+    }
+
+
+    @Test
+    fun clearAllFavoritesThrowsNotYetImplemented() {
+        // Assemble
+
+        // Act
+        val result = transportDataStore.clearAllFavorites().test()
+        // Assert
+        result.assertError(NotImplementedError::class.java)
+    }
+
+    @Test
+    fun requestTransportEtaThrowsNotYetImplemented() {
+        // Assemble
+
+        // Act
+        val result = transportDataStore.requestTransportEta(DataFactory.randomInt()).test()
+        // Assert
+        result.assertError(NotImplementedError::class.java)
+    }
+
+
+    @Test
+    fun cancelTransportEtaRequestThrowsNotYetImplemented() {
+        // Assemble
+
+        // Act
+        val result = transportDataStore.cancelTransportEtaRequest(DataFactory.randomInt()).test()
+        // Assert
+        result.assertError(NotImplementedError::class.java)
+    }
+
+
+    /**
+     * Should use SharedPreferences for v1.0 only
+     */
+    @Test
+    fun saveTransportCompletes() {
+        // Assemble
+        val stubbedModel = robot.stubFrameworkLocalStorageSaveTransportSuccess()
+        // Act
+        val testObserver = transportDataStore.saveTransport(stubbedModel).test()
+        // Assert
+        testObserver.assertComplete()
+    }
+
+    /**
+     * Should use SharedPreferences for v1.0 only
+     */
+    @Test
+    fun saveTransportCallsCorrectMethodOnFrameworkLocalStorage() {
+        // Assemble
+        val stubbedModel = robot.stubFrameworkLocalStorageSaveTransportSuccess()
+        // Act
+        transportDataStore.saveTransport(stubbedModel)
+        // Assert
+        verify(mockFrameworkLocalStorage, times(1)).saveTransport(stubbedModel)
+    }
+
+    /**
+     * Should use SharedPreferences for v1.0 only
+     */
+    @Test
+    fun saveTransportFailsThrowsException() {
+        // Assemble
+        val errorMessage = "Testing Save transport fails"
+        robot.stubFrameworkLocalStorageSaveTransportFails(errorMessage)
+        // Act
+        val testObserver = transportDataStore.saveTransport(TransportFactory.makeTransportEntity()).test()
+        // Assert
+        testObserver.assertErrorMessage(errorMessage)
+    }
+
+
+    /**
+     * Should use SharedPreferences for v1.0 only
+     */
+    @Test
+    fun deleteTransportCompletes() {
+        // Assemble
+        val stubbedId = robot.stubFrameworkLocalStorageDeleteTransportSuccess()
+        // Act
+        val testObserver = transportDataStore.deleteTransport(stubbedId).test()
+        // Assert
+        testObserver.assertComplete()
+    }
+
+    /**
+     * Should use SharedPreferences for v1.0 only
+     */
+    @Test
+    fun deleteTransportCallsCorrectMethodOnFrameworkLocalStorage() {
+        // Assemble
+        val stubbedId = robot.stubFrameworkLocalStorageDeleteTransportSuccess()
+        // Act
+        transportDataStore.deleteTransport(stubbedId)
+        // Assert
+        verify(mockFrameworkLocalStorage, times(1)).deleteTransport(stubbedId)
+    }
+
+    /**
+     * Should use SharedPreferences for v1.0 only
+     */
+    @Test
+    fun deleteTransportFailsThrowsException() {
+        // Assemble
+        val errorMessage = "Testing Delete transport fails"
+        robot.stubFrameworkLocalStorageDeleteTransportFails(errorMessage)
+        // Act
+        val testObserver = transportDataStore.deleteTransport(DataFactory.randomUuid()).test()
+        // Assert
+        testObserver.assertErrorMessage(errorMessage)
+    }
+
+
+    /**
+     * Should use SharedPreferences for v1.0 only
+     */
+    @Test
+    fun getTransportCompletes() {
+        // Assemble
+        val stubbedTransportEntity = robot.stubFrameworkLocalStorageGetTransportSuccess()
+        // Act
+        val testObserver = transportDataStore.getTransport(stubbedTransportEntity.id).test()
+        // Assert
+        testObserver.assertComplete()
+    }
+
+    /**
+     * Should use SharedPreferences for v1.0 only
+     */
+    @Test
+    fun getTransportCallsCorrectMethodOnFrameworkLocalStorage() {
+        // Assemble
+        val stubbedTransportEntity = robot.stubFrameworkLocalStorageGetTransportSuccess()
+        // Act
+        transportDataStore.getTransport(stubbedTransportEntity.id)
+        // Assert
+        verify(mockFrameworkLocalStorage, times(1)).getTransport(stubbedTransportEntity.id)
+    }
+
+    /**
+     * Should use SharedPreferences for v1.0 only
+     */
+    @Test
+    fun getTransportFailsThrowsException() {
+        // Assemble
+        val errorMessage = "Testing Get transport fails"
+        robot.stubFrameworkLocalStorageGetTransportFails(errorMessage)
+        // Act
+        val testObserver = transportDataStore.getTransport(DataFactory.randomUuid()).test()
+        // Assert
+        testObserver.assertErrorMessage(errorMessage)
+    }
+
+    /**
+     * Should use SharedPreferences for v1.0 only
+     */
+    @Test
+    fun getAllCompletes() {
+        // Assemble
+        robot.stubFrameworkLocalStorageGetAllSuccess()
+        // Act
+        val testObserver = transportDataStore.getAll().test()
+        // Assert
+        testObserver.assertComplete()
+    }
+
+    /**
+     * Should use SharedPreferences for v1.0 only
+     */
+    @Test
+    fun getAllCorrectMethodOnFrameworkLocalStorage() {
+        // Assemble
+        robot.stubFrameworkLocalStorageGetAllSuccess()
+        // Act
+        transportDataStore.getAll()
+        // Assert
+        verify(mockFrameworkLocalStorage, times(1)).getAll()
+    }
+
+    /**
+     * Should use SharedPreferences for v1.0 only
+     */
+    @Test
+    fun getAllFailsThrowsException() {
+        // Assemble
+        val errorMessage = "Testing Get All fails"
+        robot.stubFrameworkLocalStorageGetAllFails(errorMessage)
+        // Act
+        val testObserver = transportDataStore.getAll().test()
+        // Assert
+        testObserver.assertErrorMessage(errorMessage)
+    }
+
+
+    inner class Robot {
+
+        fun stubFrameworkLocalStorageGetAllSuccess(transportEntityList: List<TransportEntity> = TransportFactory.makeTransportEntityList(5)): List<TransportEntity> {
+            whenever(mockFrameworkLocalStorage.getAll()).then { Single.just(transportEntityList) }
+            return transportEntityList
+        }
+
+        fun stubFrameworkLocalStorageGetAllFails(message: String = DataFactory.randomUuid()): Throwable {
+            val throwable = Throwable(message)
+            whenever(mockFrameworkLocalStorage.getAll()).then { Single.error<Throwable>(throwable) }
+            return throwable
+        }
+
+        fun stubFrameworkLocalStorageGetTransportSuccess(transportEntity: TransportEntity = TransportFactory.makeTransportEntity()): TransportEntity {
+            whenever(mockFrameworkLocalStorage.getTransport(transportEntity.id)).then { Single.just(transportEntity) }
+            return transportEntity
+        }
+
+        fun stubFrameworkLocalStorageGetTransportFails(message: String = DataFactory.randomUuid()): Throwable {
+            val throwable = Throwable(message)
+            whenever(mockFrameworkLocalStorage.getTransport(any())).then { Single.error<Throwable>(throwable) }
+            return throwable
+        }
+
+        fun stubFrameworkLocalStorageSaveTransportSuccess(transportEntity: TransportEntity = TransportFactory.makeTransportEntity()): TransportEntity {
+            whenever(mockFrameworkLocalStorage.saveTransport(transportEntity)).then { Completable.complete() }
+            return transportEntity
+        }
+
+        fun stubFrameworkLocalStorageSaveTransportFails(message: String = DataFactory.randomUuid()): Throwable {
+            val throwable = Throwable(message)
+            whenever(mockFrameworkLocalStorage.saveTransport(any())).then { Completable.error(throwable) }
+            return throwable
+        }
+
+        fun stubFrameworkLocalStorageDeleteTransportSuccess(transportId: String = DataFactory.randomUuid()): String {
+            whenever(mockFrameworkLocalStorage.deleteTransport(transportId)).then { Completable.complete() }
+            return transportId
+        }
+
+        fun stubFrameworkLocalStorageDeleteTransportFails(message: String = DataFactory.randomUuid()): Throwable {
+            val throwable = Throwable(message)
+            whenever(mockFrameworkLocalStorage.deleteTransport(any())).then { Completable.error(throwable) }
+            return throwable
+
+        }
+    }
+
+}

--- a/transport-eta-android/sms/src/test/java/com/joaquimley/SmsControllerTest.kt
+++ b/transport-eta-android/sms/src/test/java/com/joaquimley/SmsControllerTest.kt
@@ -17,7 +17,7 @@ class SmsControllerTest {
     private val robot = Robot()
     private val mockSmsBroadcastReceiver = mock<SmsBroadcastReceiver>()
 
-    lateinit var smsController: SmsController
+    private lateinit var smsController: SmsController
 
     @Before
     fun setup() {

--- a/transport-eta-android/ui-mobile/src/main/java/com/joaquimley/transporteta/ui/di/component/AppComponent.kt
+++ b/transport-eta-android/ui-mobile/src/main/java/com/joaquimley/transporteta/ui/di/component/AppComponent.kt
@@ -16,6 +16,7 @@ import dagger.android.support.AndroidSupportInjectionModule
     MapperModule::class,
     ViewModelModule::class,
     RepositoryModule::class,
+    DataStoreModule::class,
     DataSourceModule::class,
     SmsControllerModule::class
 ])

--- a/transport-eta-android/ui-mobile/src/main/java/com/joaquimley/transporteta/ui/di/module/DataStoreModule.kt
+++ b/transport-eta-android/ui-mobile/src/main/java/com/joaquimley/transporteta/ui/di/module/DataStoreModule.kt
@@ -1,18 +1,19 @@
 package com.joaquimley.transporteta.ui.di.module
 
 import com.joaquimley.data.source.FrameworkLocalStorage
-import com.joaquimley.data.source.FrameworkLocalStorageImpl
+import com.joaquimley.data.store.TransportDataStore
+import com.joaquimley.data.store.TransportDataStoreImpl
 import com.joaquimley.transporteta.ui.di.scope.PerApplication
 import dagger.Module
 import dagger.Provides
 
 @Module
-class DataSourceModule {
+class DataStoreModule {
 
     @Provides
     @PerApplication
-    fun provideSharedPreferencesDataSource(): FrameworkLocalStorage {
-        return FrameworkLocalStorageImpl()
+    fun provideSharedPreferencesDataSource(frameworkLocalStorage: FrameworkLocalStorage): TransportDataStore {
+        return TransportDataStoreImpl(frameworkLocalStorage)
     }
 
 //    @Provides

--- a/transport-eta-android/ui-mobile/src/main/java/com/joaquimley/transporteta/ui/di/module/RepositoryModule.kt
+++ b/transport-eta-android/ui-mobile/src/main/java/com/joaquimley/transporteta/ui/di/module/RepositoryModule.kt
@@ -4,6 +4,8 @@ import com.joaquimley.transporteta.domain.repository.FavoritesRepository
 import com.joaquimley.data.FavoritesRepositoryImpl
 import com.joaquimley.transporteta.domain.repository.TransportRepository
 import com.joaquimley.data.TransportRepositoryImpl
+import com.joaquimley.data.mapper.TransportMapper
+import com.joaquimley.data.store.TransportDataStore
 import com.joaquimley.transporteta.ui.di.scope.PerApplication
 import dagger.Module
 import dagger.Provides
@@ -13,14 +15,14 @@ class RepositoryModule {
 
     @Provides
     @PerApplication
-    fun provideFavoritesRepository(): FavoritesRepository {
-        return FavoritesRepositoryImpl()
+    fun provideFavoritesRepository(transportDataStore: TransportDataStore, transportMapper: TransportMapper): FavoritesRepository {
+        return FavoritesRepositoryImpl(transportDataStore, transportMapper)
     }
 
     @Provides
     @PerApplication
-    fun provideTransportRepository(): TransportRepository {
-        return TransportRepositoryImpl()
+    fun provideTransportRepository(transportDataStore: TransportDataStore, transportMapper: TransportMapper): TransportRepository {
+        return TransportRepositoryImpl(transportDataStore,transportMapper)
     }
 
 


### PR DESCRIPTION
- Unit tests

- Currently only using the (not yet implemented) FrameworkLocalStorage
  - Should be implemented by another module that uses SharedPreferences (Android Library)
  - A little hacky since SharedPrefs will always be Single events and the stream will be finished everytime

Also left a lot of NotImplementedError to methods that shouldn't be used until we have a proper DB
  SharedPrefs will be limited to only 3 saved Entities.

#69